### PR TITLE
HARD FORK - Fix: Replace jcenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
-# This is Moqui GraphQL Add-On Component
+# Fork of the Moqui GraphQL Add-On Component
+Reasons for fork ([See Original Project](shendepu/moqui-graphql)):
+- At time of writing, last commit was over a year ago and has not been actively been developed since 2018.
+- Breaking changes have been introduced because of JCenter sunsetting [see PR](https://github.com/shendepu/moqui-graphql/pull/8)
+
+
 
 This [Moqui](https://github.com/moqui/moqui-framework) add-on component adds support of [GraphQL](graphql.org) to Moqui. 
 
-The way to use it is just simliar to REST Api in moqui-framework. 
+The way to use it is just similar to REST Api in moqui-framework. 
 
 - The GraphQL endpoint is `/graphql/v1?query={graphQLQueryString}` or `/graphql/v1?query={graphQLQueryString}&&variables={graphQLVariables}` 
 - The configuration of GraphQL Schema is *.graphql.xml under service directory of component

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,10 @@ version = componentNode.@version
 // to run use "gradle dependencyUpdates"
 apply plugin: 'com.github.ben-manes.versions'
 buildscript {
-  repositories { jcenter() }
+  repositories {
+      mavenCentral()
+      gradlePluginPortal()
+  }
   dependencies { classpath 'com.github.ben-manes:gradle-versions-plugin:0.13.0' }
 }
 
@@ -23,13 +26,16 @@ dependencyUpdates.resolutionStrategy = { componentSelection { rules -> rules.all
 repositories {
     flatDir name: 'frameworkLib', dirs: frameworkDir.absolutePath + '/lib'
     //flatDir name: 'localLib', dirs: projectDir.absolutePath + '/lib'
-    jcenter()
-    maven { url "http://dl.bintray.com/andimarek/graphql-java" }
+    mavenCentral()
 }
 
 dependencies {
     compile project(':framework')
+    implementation 'org.elasticsearch.client:transport:7.5.1'
+
     compile 'com.graphql-java:graphql-java:4.2'
+    compile 'org.antlr:antlr4-runtime:4.5.3'
+
     testCompile project(':framework').configurations.testCompile.allDependencies
 }
 
@@ -71,3 +77,4 @@ test {
 
     beforeTest { descriptor -> logger.lifecycle("Running test: ${descriptor}") }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -31,10 +31,8 @@ repositories {
 
 dependencies {
     compile project(':framework')
-    implementation 'org.elasticsearch.client:transport:7.5.1'
 
     compile 'com.graphql-java:graphql-java:4.2'
-    compile 'org.antlr:antlr4-runtime:4.5.3'
 
     testCompile project(':framework').configurations.testCompile.allDependencies
 }
@@ -77,4 +75,3 @@ test {
 
     beforeTest { descriptor -> logger.lifecycle("Running test: ${descriptor}") }
 }
-


### PR DESCRIPTION
# Fork of the Moqui GraphQL Add-On Component
Reasons for fork ([See Original Project](shendepu/moqui-graphql)):
- At time of writing, last commit was over a year ago and has not been actively been developed since 2018.
- Breaking changes have been introduced because of JCenter sunsetting [see PR](https://github.com/shendepu/moqui-graphql/pull/8)